### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -9,13 +9,13 @@
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-get KEYWORD2
-set KEYWORD2
-read KEYWORD2
-write KEYWORD2
-readAlarm KEYWORD2
-writeAlarm KEYWORD2
-readRegisters KEYWORD2
+get	KEYWORD2
+set	KEYWORD2
+read	KEYWORD2
+write	KEYWORD2
+readAlarm	KEYWORD2
+writeAlarm	KEYWORD2
+readRegisters	KEYWORD2
 #######################################
 # Instances (KEYWORD2)
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords